### PR TITLE
Content and image box for homepage

### DIFF
--- a/app/components/content-and-image-box.tsx
+++ b/app/components/content-and-image-box.tsx
@@ -31,44 +31,47 @@ export const ContentAndImageBox = ({
 
   className: initialClassName = "",
   contentBoxClassName: initialContentBoxClassName = "bg-blue-300",
-  imageBoxClassName:
-    initialImageBoxClassName = "bg-gradient-to-bl from-lime-600 via-teal-400 to-emerald-400",
+  imageBoxClassName: initialImageBoxClassName = "bg-white",
 }: Props) => {
   let className = initialClassName;
   let contentBoxClassName = initialContentBoxClassName;
   let imageBoxClassName = initialImageBoxClassName;
 
   if (direction === "left") {
-    className += "flex-col md:flex-row";
+    className += " md:flex-row ";
     contentBoxClassName += " md:pl-[40px] md:pr-[100px]";
     imageBoxClassName += " md:-ml-[100px]";
   }
   if (direction === "right") {
-    className += "flex-col md:flex-row-reverse";
+    className += " md:flex-row-reverse";
     contentBoxClassName += " md:pl-[100px]";
     imageBoxClassName += " md:-mr-[100px]";
   }
 
   return (
-    <Todo badge title="" className="border-none px-0 py-0">
-      <div className={`flex items-center ${className}`}>
-        <div
-          className={`w-full md:w-[40vw] lg:w-[60w] md:min-w-[500px] flex flex-col justify-center ${contentBoxClassName}`}
-          style={{ height }}
-        >
-          <div className="p-[2vw] pb-0 text-2xl font-semibold">{title}</div>
-          <div className="p-[2vw] whitespace-pre-line">{children}</div>
+    <div
+      className={`flex-col-reverse flex w-full justify-center items-center ${className}`}
+    >
+      <div
+        className={`w-full md:w-[40vw] lg:w-[60w] md:min-w-[500px] flex flex-col justify-center ${contentBoxClassName}`}
+        style={{ height }}
+      >
+        <div className="p-[2vw] pb-0 text-2xl md:text-4xl text-secondary font-bold">
+          {title}
         </div>
-
-        <div
-          className={`relative h-[30vw] aspect-square shadow-lg ${imageBoxClassName}`}
-        >
-          <div className="absolute top-0 w-full">
-            <Todo size="small" badge title="fancy patterns" />
-          </div>
-          {image}
+        <div className="p-[2vw] whitespace-pre-line text-md md:text-lg text-secondary">
+          {children}
         </div>
       </div>
-    </Todo>
+
+      <div
+        className={`relative max-h-60 md:h-[30vw] md:max-h-96 aspect-square shadow-xl ${imageBoxClassName}`}
+      >
+        <div className="absolute top-0 w-full">
+          <Todo size="small" badge title="fancy patterns" />
+        </div>
+        {image}
+      </div>
+    </div>
   );
 };

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,14 +1,13 @@
 import type { MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-
-import type { SanityImageObject } from "@sanity/image-url/lib/types/types";
 
 import { ContactForm } from "~/components/contact-form";
 import { ContentAndImageBox } from "~/components/content-and-image-box";
 import { TitleAndText } from "~/components/title-and-text";
 import { Todo } from "~/components/todo";
 import { sanityClient } from "~/sanity/sanity-client.server";
-import { urlFor } from "~/utils/imageBuilder";
+import { getImageObjectWithDefaultImages } from "~/utils/dataRetrieval";
 
 export const meta: MetaFunction = () => ({
   title: "Capra Consulting: IT-konsulenter med ekspertise i software",
@@ -18,20 +17,13 @@ export const meta: MetaFunction = () => ({
 });
 
 export const loader = async () => {
+  const imageNames = ["tech", "aws"] as const;
   const data = await sanityClient.getAll(
     "imageAsset",
-    "title in ['tech', 'aws']",
+    `title in ${JSON.stringify(imageNames)}`,
   );
-  const images: Record<string, { imageUrl: string; alt: string }> = {};
-  data.forEach((asset) => {
-    if (asset?.title) {
-      images[asset.title] = {
-        imageUrl: urlFor(asset.image as SanityImageObject).url(),
-        alt: asset.imageAlt ?? "",
-      };
-    }
-  });
-  return images; // TODO: Return default image on error. Do not crash site
+
+  return json(getImageObjectWithDefaultImages(imageNames, data));
 };
 
 export default function Index() {

--- a/app/sanity/config.ts
+++ b/app/sanity/config.ts
@@ -1,0 +1,6 @@
+export const config = {
+  apiVersion: "2021-03-25",
+  dataset: process.env.SANITY_DATASET || "production",
+  projectId: process.env.SANITY_PROJECT_ID || "3drrs17h",
+  useCdn: false,
+};

--- a/app/sanity/getPicoClient.ts
+++ b/app/sanity/getPicoClient.ts
@@ -1,0 +1,5 @@
+import PicoSanity from "picosanity";
+
+import { config } from "./config";
+
+export const picoSanityClient = new PicoSanity(config);

--- a/app/sanity/getPicoClient.ts
+++ b/app/sanity/getPicoClient.ts
@@ -1,5 +1,0 @@
-import PicoSanity from "picosanity";
-
-import { config } from "./config";
-
-export const picoSanityClient = new PicoSanity(config);

--- a/app/sanity/schema.ts
+++ b/app/sanity/schema.ts
@@ -293,6 +293,129 @@ export interface Category extends SanityDocument {
 }
 
 /**
+ * Faktaboks
+ *
+ *
+ */
+export interface Factbox extends SanityDocument {
+  _type: "factbox";
+
+  /**
+   * Navn i venstrekolonne her inne — `string`
+   *
+   * Brukes aldri utenfor Sanity studio
+   */
+  title?: string;
+
+  /**
+   * Overskrift — `string`
+   *
+   *
+   */
+  titleLong?: string;
+
+  /**
+   * Beskrivelse — `text`
+   *
+   *
+   */
+  description?: string;
+
+  /**
+   * Tjenester fra — `string`
+   *
+   *
+   */
+  servicesName?: string;
+
+  /**
+   * Tjenester fra (url) — `url`
+   *
+   *
+   */
+  servicesUrl?: string;
+
+  /**
+   * Tjenesteliste — `array`
+   *
+   *
+   */
+  servicesList?: Array<SanityKeyedReference<Services>>;
+}
+
+/**
+ * Bilderessurser
+ *
+ *
+ */
+export interface ImageAsset extends SanityDocument {
+  _type: "imageAsset";
+
+  /**
+   * Tittel — `string`
+   *
+   *
+   */
+  title?: string;
+
+  /**
+   * Asset — `image`
+   *
+   *
+   */
+  image?: {
+    _type: "image";
+    asset: SanityReference<SanityImageAsset>;
+    crop?: SanityImageCrop;
+    hotspot?: SanityImageHotspot;
+  };
+
+  /**
+   * Alt tekst — `string`
+   *
+   * Alt tekst
+   */
+  imageAlt?: string;
+
+  /**
+   * Image description — `string`
+   *
+   *
+   */
+  description?: string;
+}
+
+/**
+ * Teams og stillinger
+ *
+ *
+ */
+export interface JobCategory extends SanityDocument {
+  _type: "jobCategory";
+
+  /**
+   * Navn — `string`
+   *
+   *
+   */
+  title?: string;
+
+  /**
+   * Formål — `text`
+   *
+   *
+   */
+  purpose?: string;
+
+  /**
+   * Synlig i orgnisasjonskart? — `boolean`
+   *
+   *
+   */
+  visibleInOrgChart?: boolean;
+}
+
+/**
  * Selvskryt
  *
  *
@@ -443,110 +566,6 @@ export interface Services extends SanityDocument {
   description?: string;
 }
 
-/**
- * Faktaboks
- *
- *
- */
-export interface Factbox extends SanityDocument {
-  _type: "factbox";
-
-  /**
-   * Navn i venstrekolonne her inne — `string`
-   *
-   * Brukes aldri utenfor Sanity studio
-   */
-  title?: string;
-
-  /**
-   * Overskrift — `string`
-   *
-   *
-   */
-  titleLong?: string;
-
-  /**
-   * Beskrivelse — `text`
-   *
-   *
-   */
-  description?: string;
-
-  /**
-   * Tjenester fra — `string`
-   *
-   *
-   */
-  servicesName?: string;
-
-  /**
-   * Tjenester fra (url) — `url`
-   *
-   *
-   */
-  servicesUrl?: string;
-
-  /**
-   * Tjenesteliste — `array`
-   *
-   *
-   */
-  servicesList?: Array<SanityKeyedReference<Services>>;
-}
-
-/**
- * Teams og stillinger
- *
- *
- */
-export interface JobCategory extends SanityDocument {
-  _type: "jobCategory";
-
-  /**
-   * Navn — `string`
-   *
-   *
-   */
-  title?: string;
-
-  /**
-   * Formål — `text`
-   *
-   *
-   */
-  purpose?: string;
-
-  /**
-   * Synlig i orgnisasjonskart? — `boolean`
-   *
-   *
-   */
-  visibleInOrgChart?: boolean;
-}
-
-export type RichText = Array<
-  | SanityKeyed<SanityBlock>
-  | SanityKeyed<RichTextImage>
-  | SanityKeyed<Code>
-  | SanityKeyed<Youtube>
-  | SanityKeyed<{
-      _type: "image";
-      asset: SanityReference<SanityImageAsset>;
-      crop?: SanityImageCrop;
-      hotspot?: SanityImageHotspot;
-    }>
->;
-
-export type Youtube = {
-  _type: "youtube";
-  /**
-   * YouTube video URL — `url`
-   *
-   *
-   */
-  url?: string;
-};
-
 export type MainImage = {
   _type: "mainImage";
   asset: SanityReference<SanityImageAsset>;
@@ -568,6 +587,19 @@ export type MainImage = {
   alt?: string;
 };
 
+export type RichText = Array<
+  | SanityKeyed<SanityBlock>
+  | SanityKeyed<RichTextImage>
+  | SanityKeyed<Code>
+  | SanityKeyed<Youtube>
+  | SanityKeyed<{
+      _type: "image";
+      asset: SanityReference<SanityImageAsset>;
+      crop?: SanityImageCrop;
+      hotspot?: SanityImageHotspot;
+    }>
+>;
+
 export type RichTextImage = {
   _type: "richTextImage";
   asset: SanityReference<SanityImageAsset>;
@@ -584,13 +616,23 @@ export type RichTextImage = {
   /**
        * Alternative text — `text`
        *
-       * Some of your visitors cannot see images, 
-            be they blind, color-blind, low-sighted; 
-            alternative text is of great help for those 
-            people that can rely on it to have a good idea of 
+       * Some of your visitors cannot see images,
+            be they blind, color-blind, low-sighted;
+            alternative text is of great help for those
+            people that can rely on it to have a good idea of
             what's on your page.
        */
   alt?: string;
+};
+
+export type Youtube = {
+  _type: "youtube";
+  /**
+   * YouTube video URL — `url`
+   *
+   *
+   */
+  url?: string;
 };
 
 export type BlockContent = Array<
@@ -602,11 +644,12 @@ export type Documents =
   | Blogg
   | Bloggfilter
   | Category
+  | Factbox
+  | ImageAsset
+  | JobCategory
   | Selvskryt
   | Selvskrytfilter
-  | Services
-  | Factbox
-  | JobCategory;
+  | Services;
 
 /**
  * This interface is a stub. It was referenced in your sanity schema but

--- a/app/utils/dataRetrieval.ts
+++ b/app/utils/dataRetrieval.ts
@@ -1,0 +1,40 @@
+import type { SanityImageObject } from "@sanity/image-url/lib/types/types";
+
+import type { ImageAsset } from "~/sanity/schema";
+import { urlFor } from "./imageBuilder";
+
+type Images<T extends string> = Record<T, { imageUrl: string; alt: string }>;
+
+export const getImageObjectWithDefaultImages = <T extends readonly string[]>(
+  imageNames: T,
+  data: ({
+    _type: "imageAsset";
+  } & ImageAsset)[],
+) => {
+  type ArrayElement = T[number];
+  type ReturnType = Images<ArrayElement>;
+  const retrievedImages = data.reduce<ReturnType>(
+    (images, asset) =>
+      asset.title
+        ? {
+            ...images,
+            [asset.title]: {
+              imageUrl: urlFor(asset.image as SanityImageObject).url(),
+              alt: asset.imageAlt ?? "",
+            },
+          }
+        : images,
+    {} as ReturnType,
+  );
+
+  return imageNames.reduce<ReturnType>(
+    (images, imageName) => ({
+      ...images,
+      [imageName]:
+        imageName in retrievedImages
+          ? retrievedImages[imageName as ArrayElement]
+          : { imageUrl: "", alt: "" }, // TODO: Supply default image
+    }),
+    {} as ReturnType,
+  );
+};

--- a/app/utils/imageBuilder.ts
+++ b/app/utils/imageBuilder.ts
@@ -1,8 +1,8 @@
 import imageUrlBuilder from "@sanity/image-url";
 import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 
-import { picoSanityClient } from "../sanity/getPicoClient";
+import { config } from "~/sanity/config";
 
-const builder = imageUrlBuilder(picoSanityClient);
+const builder = imageUrlBuilder(config);
 
 export const urlFor = (source: SanityImageSource) => builder.image(source);

--- a/app/utils/imageBuilder.ts
+++ b/app/utils/imageBuilder.ts
@@ -1,0 +1,8 @@
+import imageUrlBuilder from "@sanity/image-url";
+import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
+import { picoSanityClient } from "../sanity/getPicoClient";
+
+const builder = imageUrlBuilder(picoSanityClient);
+
+export const urlFor = (source: SanityImageSource) => builder.image(source);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@sanity/image-url": "^1.0.1",
         "cross-env": "7.0.3",
         "isbot": "3.5.0",
-        "picosanity": "^4.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "sanity-codegen": "0.9.8"
@@ -10799,6 +10798,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11606,17 +11606,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/picosanity": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/picosanity/-/picosanity-4.0.0.tgz",
-      "integrity": "sha512-WM0GXBEXNgA4v/NfGt5xiARLI1qMKLBJ3+OQkJ82MFbLduAi+xg6PdC5BVXVRnXzXRSnl9PkUh/hYRScu6/cqA==",
-      "dependencies": {
-        "node-fetch": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/pidtree": {
@@ -14504,7 +14493,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/trough": {
       "version": "2.1.0",
@@ -15495,7 +15485,8 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -15534,6 +15525,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -23576,6 +23568,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -24179,14 +24172,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
-    },
-    "picosanity": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/picosanity/-/picosanity-4.0.0.tgz",
-      "integrity": "sha512-WM0GXBEXNgA4v/NfGt5xiARLI1qMKLBJ3+OQkJ82MFbLduAi+xg6PdC5BVXVRnXzXRSnl9PkUh/hYRScu6/cqA==",
-      "requires": {
-        "node-fetch": "^2.6.0"
-      }
     },
     "pidtree": {
       "version": "0.3.1",
@@ -26412,7 +26397,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "trough": {
       "version": "2.1.0",
@@ -27056,7 +27042,8 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "2.0.0",
@@ -27088,6 +27075,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "@remix-run/node": "1.6.5",
         "@remix-run/react": "1.6.5",
         "@remix-run/server-runtime": "1.6.5",
+        "@sanity/image-url": "^1.0.1",
         "cross-env": "7.0.3",
         "isbot": "3.5.0",
+        "picosanity": "^4.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "sanity-codegen": "0.9.8"
@@ -2923,6 +2925,14 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw==",
       "dev": true
+    },
+    "node_modules/@sanity/image-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-1.0.1.tgz",
+      "integrity": "sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -10789,7 +10799,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11597,6 +11606,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/picosanity": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/picosanity/-/picosanity-4.0.0.tgz",
+      "integrity": "sha512-WM0GXBEXNgA4v/NfGt5xiARLI1qMKLBJ3+OQkJ82MFbLduAi+xg6PdC5BVXVRnXzXRSnl9PkUh/hYRScu6/cqA==",
+      "dependencies": {
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/pidtree": {
@@ -14484,8 +14504,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/trough": {
       "version": "2.1.0",
@@ -15476,8 +15495,7 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
@@ -15516,7 +15534,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -17862,6 +17879,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw==",
       "dev": true
+    },
+    "@sanity/image-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-1.0.1.tgz",
+      "integrity": "sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -23554,7 +23576,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -24158,6 +24179,14 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "picosanity": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/picosanity/-/picosanity-4.0.0.tgz",
+      "integrity": "sha512-WM0GXBEXNgA4v/NfGt5xiARLI1qMKLBJ3+OQkJ82MFbLduAi+xg6PdC5BVXVRnXzXRSnl9PkUh/hYRScu6/cqA==",
+      "requires": {
+        "node-fetch": "^2.6.0"
+      }
     },
     "pidtree": {
       "version": "0.3.1",
@@ -26383,8 +26412,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "trough": {
       "version": "2.1.0",
@@ -27028,8 +27056,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-encoding": {
       "version": "2.0.0",
@@ -27061,7 +27088,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "@remix-run/node": "1.6.5",
     "@remix-run/react": "1.6.5",
     "@remix-run/server-runtime": "1.6.5",
+    "@sanity/image-url": "^1.0.1",
     "cross-env": "7.0.3",
     "isbot": "3.5.0",
+    "picosanity": "^4.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "sanity-codegen": "0.9.8"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@sanity/image-url": "^1.0.1",
     "cross-env": "7.0.3",
     "isbot": "3.5.0",
-    "picosanity": "^4.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "sanity-codegen": "0.9.8"


### PR DESCRIPTION
The sanity client from sanity-codegen is very minimal and does not support fetching image urls. Had to add `picosanity` and  this [image builder](https://www.sanity.io/plugins/image-url) to fetch them. Through this, we get a lot of nice features for transforming the image, and it does so by just modifying the image url. Thus, we don't actually have to fetch the image. See [here](https://www.sanity.io/docs/image-urls#crop-object-object) for more details about the Sanity image url.

Also added support for image assets in Sanity in a [previous commit](https://github.com/capraconsulting/nettsiden/commit/bdfceb0c06f2fbb5400e4c4e0ec4e57c1b76f250).