### PR TITLE
🧱 fix sanity studio deployment, matching all routes

### DIFF
--- a/studio/netlify.toml
+++ b/studio/netlify.toml
@@ -2,3 +2,8 @@
 
 [build]
   ignore = "git diff --quiet HEAD^ HEAD ./"
+
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
Sanity studio runs as a single page application, while netlify by default only looks at the actual files created by the build.

By adding the redirect config, all routes will serve the index.html file which again defers routing to the studio SPA.

I think this explains why the old website configuration had the * redirect, though it affect both studio AND web deployment.
https://github.com/capraconsulting/capraconsulting.no/blob/master/netlify.toml#L9-L12