### PR TITLE
:zap: create img abstraction adding lazy loading and async decoding

### DIFF
--- a/app/components/ProsableText.tsx
+++ b/app/components/ProsableText.tsx
@@ -8,6 +8,7 @@ import github from "prism-react-renderer/themes/github";
 import type { BlockContent } from "~/sanity/schema";
 import { urlFor } from "~/utils/imageBuilder";
 import { classNames } from "~/utils/misc";
+import { CapraImage } from "./capra-image";
 import { CapraLink } from "./capra-link";
 
 interface PrismProps {
@@ -43,7 +44,10 @@ function Image(props: PortableTextTypeComponentProps<any>) {
 
   return (
     <figure>
-      <img alt={props.value.alt ?? ""} src={urlFor(props.value.asset).url()} />
+      <CapraImage
+        alt={props.value.alt ?? ""}
+        src={urlFor(props.value.asset).url()}
+      />
       <figcaption>{props.value.caption}</figcaption>
     </figure>
   );

--- a/app/components/capra-image.tsx
+++ b/app/components/capra-image.tsx
@@ -1,0 +1,19 @@
+type ImageProps = React.ComponentProps<"img"> & { alt: string };
+
+const DEFAULT: React.ComponentProps<"img"> = {
+  // Makes the image not load before scrolling into view
+  // Very useful for pages showing lots of images, or when there are images at bottom
+  loading: "lazy",
+
+  // This seems to be the default in most or all other img abstractions
+  decoding: "async",
+};
+
+// TODO:
+// - [] Prop for sanity imageUrl
+// - [] Prop for sanity imageObject
+// - [] Generate srcset
+// - [] Placeholder
+export const CapraImage = (props: ImageProps) => {
+  return <img {...DEFAULT} {...props} alt={props.alt} />;
+};

--- a/app/components/capra-image.tsx
+++ b/app/components/capra-image.tsx
@@ -5,8 +5,12 @@ const DEFAULT: React.ComponentProps<"img"> = {
   // Very useful for pages showing lots of images, or when there are images at bottom
   loading: "lazy",
 
-  // This seems to be the default in most or all other img abstractions
-  decoding: "async",
+  // `decoding="async" seems to be the default in most or all other img abstractions
+  // Like Next 13
+  // But without placeholder tricks and such this causes a quick flash when first loading a page with images visible,
+  // not so nice.
+  // we can consider this at a later time, maybe it's an edge case and the tradeoff is worth it.
+  // decoding: "async",
 };
 
 // TODO:

--- a/app/components/card.stories.tsx
+++ b/app/components/card.stories.tsx
@@ -1,5 +1,6 @@
 import { socialIcons } from "~/utils/constants";
 import { Badge } from "./badge";
+import { CapraImage } from "./capra-image";
 import { Card } from "./card";
 
 export const CardStories = () => {
@@ -8,7 +9,7 @@ export const CardStories = () => {
       <a href="#dette-har-vi-gjort">
         <Card
           image={
-            <img
+            <CapraImage
               alt=""
               src="https://cdn.sanity.io/images/3drrs17h/production/3caf38fa7022149f24f434951d4d126587c19837-800x449.png?w=800&h=449&auto=format"
             />
@@ -32,7 +33,7 @@ export const CardStories = () => {
       <a href="#Blogg">
         <Card
           image={
-            <img
+            <CapraImage
               src="https://cdn.sanity.io/images/3drrs17h/production/526b9fe08148af1a6c296a57013476b6d6071427-1920x1285.jpg?w=1366&h=914&auto=format"
               alt=""
             />
@@ -94,7 +95,7 @@ export const CardStories = () => {
       </Card>
       <Card
         image={
-          <img
+          <CapraImage
             alt=""
             src="https://cdn.sanity.io/images/3drrs17h/production/245fc89dfead5d9a4049b5fcf0e44238bac396ce-4500x3000.jpg?rect=750,0,3000,3000&w=1600&h=1600&auto=format"
           />

--- a/app/components/contact-form.tsx
+++ b/app/components/contact-form.tsx
@@ -7,6 +7,7 @@ import type { SanityImageAsset, SanityReference } from "sanity-codegen";
 import { Button } from "~/components/button";
 import type { action as contactAction } from "~/routes/api.contact";
 import { urlFor } from "~/utils/imageBuilder";
+import { CapraImage } from "./capra-image";
 import { CapraLink } from "./capra-link";
 
 interface ContactFormProps {
@@ -113,7 +114,7 @@ const Representatives = ({ representatives }: RepresentativesProps) => {
     <div className="grid grid-flow-dense grid-cols-1 md:grid-cols-2 gap-y-5 gap-x-14 px-5">
       {representatives.map(({ name, email, image }) => (
         <div key={name} className="flex flex-col">
-          <img
+          <CapraImage
             className=""
             alt={`Bilde av ${name}`}
             src={urlFor(image).size(600, 600).url()}

--- a/app/components/content-and-slogans-box.tsx
+++ b/app/components/content-and-slogans-box.tsx
@@ -1,4 +1,5 @@
 import { classNames } from "~/utils/misc";
+import { CapraImage } from "./capra-image";
 import { CapraLink } from "./capra-link";
 
 interface Slogan {
@@ -86,11 +87,11 @@ export const ContentAndSlogansBox = ({
               "aspect-square",
             )}
           >
-            <img className="mt-[20%] w-[40%]" src={imageUrl} alt="" />
+            <CapraImage className="mt-[20%] w-[40%]" src={imageUrl} alt="" />
             <p className="font-bold absolute bottom-[20%]">{title}</p>
           </div>
         ))}
-        <img src={illustrationImageUrl} alt="" />
+        <CapraImage src={illustrationImageUrl} alt="" />
       </div>
     </div>
   );

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/utils/constants";
 import type { Images } from "~/utils/dataRetrieval";
 import { capitalize, formatPhoneNumber } from "~/utils/misc";
+import { CapraImage } from "./capra-image";
 
 interface FooterModuleProps {
   title: string;
@@ -152,7 +153,7 @@ export const Footer = ({ images }: FooterProps) => (
             rel="noopener noreferrer"
             title="EKT Rideskole og Husdyrpark"
           >
-            <img
+            <CapraImage
               className="p-1 w-20 rounded bg-white"
               src={images["logo-ekt"].imageUrl}
               alt={images["logo-ekt"].alt}
@@ -169,7 +170,7 @@ export const Footer = ({ images }: FooterProps) => (
               rel="noopener noreferrer"
               title="Capra er Miljøtårnsertifisert"
             >
-              <img
+              <CapraImage
                 className="p-1 w-20 rounded bg-white"
                 src={images["logo-miljofyrtaarn"].imageUrl}
                 alt={images["logo-miljofyrtaarn"].alt}
@@ -181,7 +182,7 @@ export const Footer = ({ images }: FooterProps) => (
               rel="noopener noreferrer"
               title="Capra er ISO-9001-sertifisert - trykk for å se sertifikat"
             >
-              <img
+              <CapraImage
                 className="p-1 w-20 rounded bg-white"
                 src={images["logo-quality-sys-cert-iso-9001"].imageUrl}
                 alt={images["logo-quality-sys-cert-iso-9001"].alt}

--- a/app/routes/__layout/ansatte.tsx
+++ b/app/routes/__layout/ansatte.tsx
@@ -3,6 +3,7 @@ import type { HeadersFunction, LoaderArgs } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 
 import { Badge } from "~/components/badge";
+import { CapraImage } from "~/components/capra-image";
 import { Card } from "~/components/card";
 import { FilterRow } from "~/components/filter-row";
 import { TitleAndText } from "~/components/title-and-text";
@@ -105,7 +106,7 @@ export const AnsattCard = ({ employee, icons }: AnsattCardProps) => {
     <Card
       image={
         <div className="relative pb-[66%] md:pb-[100%]">
-          <img
+          <CapraImage
             className="absolute h-full w-full object-cover"
             alt={`Bilde av ${employee.name}`}
             src={urlFor(employee.image!)
@@ -143,7 +144,7 @@ export const AnsattCard = ({ employee, icons }: AnsattCardProps) => {
       <div className="mt-auto flex gap-1">
         {employee.linkedIn && (
           <a href={employee.linkedIn}>
-            <img
+            <CapraImage
               alt="linkedin"
               className={classes.icon}
               src={icons["icon-linkedin"].imageUrl}
@@ -152,7 +153,7 @@ export const AnsattCard = ({ employee, icons }: AnsattCardProps) => {
         )}
         {employee.twitter && (
           <a href={employee.twitter}>
-            <img
+            <CapraImage
               alt="twitter"
               className={classes.icon}
               src={icons["icon-twitter"].imageUrl}
@@ -161,7 +162,7 @@ export const AnsattCard = ({ employee, icons }: AnsattCardProps) => {
         )}
         {employee.github && (
           <a href={employee.github}>
-            <img
+            <CapraImage
               alt="github"
               className={classes.icon}
               src={icons["icon-github"].imageUrl}
@@ -170,7 +171,7 @@ export const AnsattCard = ({ employee, icons }: AnsattCardProps) => {
         )}
         {employee.website && (
           <a href={employee.website}>
-            <img
+            <CapraImage
               alt="nettside"
               className={classes.icon}
               src={icons["icon-website"].imageUrl}

--- a/app/routes/__layout/blogg/$slug.tsx
+++ b/app/routes/__layout/blogg/$slug.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from "@remix-run/react";
 import type { HeadersFunction, LoaderArgs } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 
+import { CapraImage } from "~/components/capra-image";
 import { ProseableText } from "~/components/ProsableText";
 import {
   getSanitySitemapEntries,
@@ -63,7 +64,7 @@ export default function BloggPost() {
         <time className="text-sm text-[#555]">{item.publishedAt}</time>
       </p>
 
-      <img
+      <CapraImage
         className="max-w-3xl"
         src={urlFor(item.mainImage!).url()}
         alt={getMainImageAlt(item)}

--- a/app/routes/__layout/blogg/index.tsx
+++ b/app/routes/__layout/blogg/index.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 
+import { CapraImage } from "~/components/capra-image";
 import { Card } from "~/components/card";
 import { FilterRow } from "~/components/filter-row";
 import { TitleAndText } from "~/components/title-and-text";
@@ -100,7 +101,7 @@ export const BloggCard = ({ bloggEntry }: BloggCardProps) => {
       <Card
         image={
           <div className="relative pb-[50%]">
-            <img
+            <CapraImage
               className="absolute h-full w-full object-cover"
               alt="" // TODO
               src={urlFor(bloggEntry.mainImage!)

--- a/app/routes/__layout/dette-har-vi-gjort/$slug.tsx
+++ b/app/routes/__layout/dette-har-vi-gjort/$slug.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 
+import { CapraImage } from "~/components/capra-image";
 import { ProseableText } from "~/components/ProsableText";
 import {
   getSanitySitemapEntries,
@@ -55,7 +56,7 @@ export default function DetteHarViGjortItem() {
       </h1>
       <ProseableText value={item.ingress!} className="text-brodtext text-2xl" />
 
-      <img
+      <CapraImage
         className="max-w-3xl"
         // TODO: Crop to a square
         src={urlFor(item.mainImage!).url()}

--- a/app/routes/__layout/dette-har-vi-gjort/index.tsx
+++ b/app/routes/__layout/dette-har-vi-gjort/index.tsx
@@ -8,6 +8,7 @@ import { json } from "@remix-run/server-runtime";
 
 import { Badge } from "~/components/badge";
 import { CallToActionBox } from "~/components/call-to-action-box";
+import { CapraImage } from "~/components/capra-image";
 import { Card } from "~/components/card";
 import { FilterRow } from "~/components/filter-row";
 import { TitleAndText } from "~/components/title-and-text";
@@ -107,7 +108,7 @@ export const SelvskrytCard = ({ selvskryt }: SelvskrytCardProps) => {
       <Card
         image={
           <div className="relative pb-[66%] md:pb-[100%]">
-            <img
+            <CapraImage
               className="absolute h-full w-full object-cover"
               alt={selvskryt.mainImageAlt}
               src={urlFor(selvskryt.mainImage!)

--- a/app/routes/__layout/dette-kan-vi/index.tsx
+++ b/app/routes/__layout/dette-kan-vi/index.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from "@remix-run/react";
 import type { HeadersFunction, MetaFunction } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 
+import { CapraImage } from "~/components/capra-image";
 import { ContentAndImageBox } from "~/components/content-and-image-box/content-and-image-box";
 import { ContentAndSlogansBox } from "~/components/content-and-slogans-box";
 import { TitleAndText } from "~/components/title-and-text";
@@ -58,7 +59,7 @@ export default function DetteKanVi() {
       <ContentAndImageBox
         title="Sky"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images.cloud.imageUrl}
             alt={images.cloud.alt}
@@ -77,7 +78,7 @@ export default function DetteKanVi() {
         title="Backend"
         direction="right"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images.backend.imageUrl}
             alt={images.backend.alt}
@@ -95,7 +96,7 @@ export default function DetteKanVi() {
       <ContentAndImageBox
         title="Frontend"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images.frontend.imageUrl}
             alt={images.frontend.alt}
@@ -114,7 +115,7 @@ export default function DetteKanVi() {
         title="Teknisk arkitektur"
         direction="right"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images["tech-architecture"].imageUrl}
             alt={images["tech-architecture"].alt}
@@ -131,7 +132,7 @@ export default function DetteKanVi() {
       <ContentAndImageBox
         title="Team-, prosjektleder og smidig coach"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images["project-lead"].imageUrl}
             alt={images["project-lead"].alt}

--- a/app/routes/__layout/index.tsx
+++ b/app/routes/__layout/index.tsx
@@ -5,6 +5,7 @@ import { json } from "@remix-run/server-runtime";
 import { BubbleSandwich } from "~/components/bubbles/bubble-sandwich";
 import { fetchEmployeeImages } from "~/components/bubbles/capra-helper.server";
 import { Button } from "~/components/button";
+import { CapraImage } from "~/components/capra-image";
 import { ContentAndImageBox } from "~/components/content-and-image-box/content-and-image-box";
 import { TitleAndText } from "~/components/title-and-text";
 import { TypingText } from "~/components/typing-text";
@@ -119,7 +120,7 @@ export default function Index() {
 
       <ContentAndImageBox
         title="Vi er Advanced Tier Consulting Partner"
-        image={<img src={images.aws.imageUrl} alt={images.aws.alt} />}
+        image={<CapraImage src={images.aws.imageUrl} alt={images.aws.alt} />}
         height="32vw"
         color="peach"
       >
@@ -128,7 +129,7 @@ export default function Index() {
       <ContentAndImageBox
         title="Vi er spesialister"
         image={
-          <img
+          <CapraImage
             className="w-full h-full object-contain overflow-hidden"
             src={images.tech.imageUrl}
             alt={images.tech.alt}
@@ -144,7 +145,7 @@ export default function Index() {
 
       <BubbleSandwich
         items={employeeImages.map((x) => (
-          <img key={x} src={x} alt="Ansatt i Capra" />
+          <CapraImage key={x} src={x} alt="Ansatt i Capra" />
         ))}
       >
         <div className="flex flex-col items-center gap-8 sm:gap-[10vh]">
@@ -168,7 +169,7 @@ export default function Index() {
         <div className="grid grid-cols-2 max-w-xl mx-auto items-center">
           {companies.map(({ alt, imageUrl }) => (
             <div key={imageUrl} className="flex justify-center items-center">
-              <img src={imageUrl} alt={alt} />
+              <CapraImage src={imageUrl} alt={alt} />
             </div>
           ))}
         </div>

--- a/app/routes/__layout/om-oss.tsx
+++ b/app/routes/__layout/om-oss.tsx
@@ -6,6 +6,7 @@ import { json } from "@remix-run/server-runtime";
 import { BubbleGrid } from "~/components/bubbles/bubble-grid";
 import { fetchEmployeeImages } from "~/components/bubbles/capra-helper.server";
 import { CallToActionBox } from "~/components/call-to-action-box";
+import { CapraImage } from "~/components/capra-image";
 import { ContentAndImageBox } from "~/components/content-and-image-box/content-and-image-box";
 import { TitleAndText } from "~/components/title-and-text";
 import { Todo } from "~/components/todo";
@@ -62,7 +63,7 @@ export default function OmOss() {
         </TitleAndText>
         <BubbleGrid
           items={employeeImages.map((x) => (
-            <img key={x} src={x} alt="Ansatt i Capra" />
+            <CapraImage key={x} src={x} alt="Ansatt i Capra" />
           ))}
         />
       </section>


### PR DESCRIPTION
lazy loading of images alone drastically improves the performance. now the browser won't fetch all the images at once and can better prioritise the images currently in the view, making them load faster and reduce flickering.

https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

Later we want more optimizations like different srcset depending size the image is displayed and perhaps a loading placeholder.

---

Jeg gjorde en search replace av alle `<img` og erstattet dem med denne `<CapraImage`. Dette er muligens litt unødvendig, men jeg mener dette er greit. Veldig fint å få lazy loading og async decoding over alt.
I de tilfellene vi ønsker noe annet er det lett å overstyre.