### PR TITLE
:sparkles: send contact-form requests to a slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ npm run dev
 
 Noen ruter trenger hemmelige API nøkkler disse finner du på [Notion](https://www.notion.so/capra/Tokens-og-s-nn-9f9b4683fefc4a0886967739754109f8), eller spør i [#team_capraweb](https://capra.slack.com/archives/C01A1QLRKJM). Men dette er ikke nødvendig for få repoet til å kjøre og gjøre endringer på de fleste sidene.
 
+```
+TEAM_TAILOR_API_KEY=<api-key-here>
+SLACK_WEBHOOK_URL=<webhook-url-here>
+```
+
 ### Ladle / Storybook
 
 Flere av felles komponentene utvikler og dokumenterer vi i [ladle](https://ladle.dev/)

--- a/app/routes/__layout/bli-en-av-oss.tsx
+++ b/app/routes/__layout/bli-en-av-oss.tsx
@@ -14,6 +14,7 @@ import { ContentAndImageBox } from "~/components/content-and-image-box/content-a
 import { TitleAndText } from "~/components/title-and-text";
 import { cacheControlHeaders } from "~/utils/cache-control";
 import { fetchImageAssets } from "~/utils/dataRetrieval";
+import { getEnv } from "~/utils/env";
 import { groupBy, typedBoolean } from "~/utils/misc";
 
 /**
@@ -66,23 +67,15 @@ interface CapraJob {
 const TEAM_TAILOR_API_VERSION = "20210218";
 
 export const loader = async ({ context }: LoaderArgs) => {
-  // Env
-  let env = {} as Partial<Record<string, unknown>>;
-  if (typeof process !== "undefined") {
-    env = { ...env, ...process.env };
-  }
-  if (context) {
-    env = { ...env, ...context };
-  }
-
-  if (!env.TEAM_TAILOR_API_KEY) {
+  const { TEAM_TAILOR_API_KEY } = getEnv({ context });
+  if (!TEAM_TAILOR_API_KEY) {
     throw new Response(`TEAM_TAILOR_API_KEY needs to be set`, {
       status: 500,
     });
   }
 
-  const headers = {
-    Authorization: `Token token=${env.TEAM_TAILOR_API_KEY}`,
+  const teamTailorRequest = {
+    Authorization: `Token token=${TEAM_TAILOR_API_KEY}`,
     "X-Api-Version": TEAM_TAILOR_API_VERSION,
   };
 
@@ -94,10 +87,10 @@ export const loader = async ({ context }: LoaderArgs) => {
       "photo-crowd-capracon",
     ]),
     fetch("https://api.teamtailor.com/v1/jobs?include=department", {
-      headers,
+      headers: teamTailorRequest,
     }).then((x) => x.json<TeamTailorJobsResponse>()),
     fetch("https://api.teamtailor.com/v1/departments", {
-      headers,
+      headers: teamTailorRequest,
     }).then((x) => x.json<TeamTailorDepartmentsResponse>()),
   ]);
 

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -1,0 +1,30 @@
+import type { AppLoadContext } from "@remix-run/server-runtime";
+
+// Make known environment variables typed, makes them more discoverable and hopefully prevents typo errors
+// They are defined as undefined or string, as they might not just be undefined
+// it's the responsiblity of the code using it to assert that it's set.
+// We could assert it in parsing code below, but then we break unrelated code if a single key is missing.
+interface Env {
+  TEAM_TAILOR_API_KEY?: string;
+  SLACK_WEBHOOK_URL?: string;
+}
+
+/**
+ * Get environment variables
+ *
+ * When running locally on node using the dev server it reads
+ * the `.env` file which is makes the variables available in `process.env`
+ *
+ * When running on cloudflare `process.env` is undefined,
+ * and instead environment variables are passed down in the AppLoadContext
+ */
+export const getEnv = ({ context }: { context: AppLoadContext }) => {
+  let env = {} as Partial<Record<string, unknown>>;
+  if (typeof process !== "undefined") {
+    env = { ...env, ...process.env };
+  }
+  if (context) {
+    env = { ...env, ...context };
+  }
+  return env as Env;
+};


### PR DESCRIPTION
using slack webhooks
https://api.slack.com/messaging/webhooks

Nå poster den i [#temp_nettsiden](https://capra.slack.com/archives/C049JLYNF0T)
<img width="330" alt="image" src="https://user-images.githubusercontent.com/244257/200026489-cbddda53-4721-4e83-aa71-284087c341f3.png">

Den bruker en webhook url for å sende meldinger, denne har jeg lagt til som en [miljøvariabel i Cloudflare](https://dash.cloudflare.com/1df81eff3a3cb0e9662170a4b25ad52b/pages/view/nettsiden/settings/environment-variables)
Og dokumenteret den [i Notion](https://www.notion.so/capra/Tokens-og-s-nn-9f9b4683fefc4a0886967739754109f8)

Vil si dette er good-enough for å gå i PROD, men noen ting som burde gjøres i ettertid

- [ ] Gjøre webhooken via slack admin, nå er den knyttet til brukeren min
- [ ] Bli enige med interessenter hvilken kanal den skal poste til
- [ ] Gjøre formatering finere i slack
- [ ] Feilhåndtering. Hva hvis ikke webhooken fungerer? Brukeren burde få klar beskjed om det. Nå tryner hele siden, som er bedre enn at den stille feiler
- [ ] Sikre oss (så godt det praktisk lar seg gjøre) mot bots og generell abuse