### PR TITLE
:art: add prettier-plugin-tailwindcss and reformat all code

### DIFF
--- a/app/components/badge.tsx
+++ b/app/components/badge.tsx
@@ -19,7 +19,7 @@ export const Badge = ({
   return (
     <span
       className={classNames(
-        "py-1 px-2 border rounded font-semibold",
+        "rounded border py-1 px-2 font-semibold",
         {
           "text-xs": size === "xs",
           "text-sm": size === "sm",

--- a/app/components/bubbles/bubble-grid.tsx
+++ b/app/components/bubbles/bubble-grid.tsx
@@ -22,7 +22,7 @@ export const BubbleGrid = ({
 
   const positions = createGridPositions(rect.width, rect.height, items.length);
   return (
-    <div className="min-h-[600px] max-w-4xl h-full w-full" ref={ref}>
+    <div className="h-full min-h-[600px] w-full max-w-4xl" ref={ref}>
       <BubbleContainer
         items={items}
         bubbleEffect={bubbleEffect}

--- a/app/components/bubbles/bubble-sandwich.tsx
+++ b/app/components/bubbles/bubble-sandwich.tsx
@@ -17,7 +17,7 @@ export const BubbleSandwich = ({
 
   return (
     <div
-      className="sm:min-h-[300px] max-w-4xl sm:grid"
+      className="max-w-4xl sm:grid sm:min-h-[300px]"
       style={{ gridTemplateColumns: "22% 54% 22%" }}
     >
       <BubbleContainer

--- a/app/components/bubbles/bubble.stories.tsx
+++ b/app/components/bubbles/bubble.stories.tsx
@@ -12,7 +12,7 @@ export const GenericBubleSandwich: Story = (props) => {
         <EmojiBubble key={x} emoji={x} />
       ))}
     >
-      <div className="text-6xl w-full h-full flex gap-2 items-center justify-center">
+      <div className="flex h-full w-full items-center justify-center gap-2 text-6xl">
         👋
       </div>
     </BubbleSandwich>
@@ -47,7 +47,7 @@ GenericBubbleGrid.argTypes = {
 };
 
 const EmojiBubble = ({ emoji }: { emoji: string }) => (
-  <div className="bg-light-blue-50 bg-opacity-50 w-full h-full flex items-center justify-center text-3xl">
+  <div className="flex h-full w-full items-center justify-center bg-light-blue-50 bg-opacity-50 text-3xl">
     {emoji}
   </div>
 );

--- a/app/components/bubbles/bubble.tsx
+++ b/app/components/bubbles/bubble.tsx
@@ -19,7 +19,7 @@ export const Bubble = ({ position, children, ...rest }: BubbleProps) => {
   return (
     <div
       className={classNames(
-        "absolute rounded-full overflow-hidden select-none transition-[top,left,width,height] ease-in-out duration-500",
+        "absolute select-none overflow-hidden rounded-full transition-[top,left,width,height] duration-500 ease-in-out",
         "border border-light-blue",
         rest.onClick && "cursor-pointer hover:scale-105 active:scale-110",
       )}

--- a/app/components/call-to-action-box.tsx
+++ b/app/components/call-to-action-box.tsx
@@ -14,9 +14,9 @@ export const CallToActionBox = ({
   href,
 }: CallToActionBoxProps) => {
   return (
-    <div className="w-11/12 max-w-7xl py-24 px-6 bg-peach-20 flex flex-col items-center gap-7 text-secondary">
-      <div className="text-center flex flex-col gap-1">
-        <p className="font-bold text-xl">{title}</p>
+    <div className="flex w-11/12 max-w-7xl flex-col items-center gap-7 bg-peach-20 py-24 px-6 text-secondary">
+      <div className="flex flex-col gap-1 text-center">
+        <p className="text-xl font-bold">{title}</p>
         <p>{description}</p>
       </div>
       <Button variant="solid" href={href}>

--- a/app/components/card.stories.tsx
+++ b/app/components/card.stories.tsx
@@ -5,7 +5,7 @@ import { Card } from "./card";
 
 export const CardStories = () => {
   return (
-    <div className="grid gap-12 sm:gap-10 md:gap-8 lg:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 justify-center">
+    <div className="grid grid-cols-1 justify-center gap-12 sm:grid-cols-2 sm:gap-10 md:gap-8 lg:grid-cols-4 lg:gap-6">
       <a href="#dette-har-vi-gjort">
         <Card
           image={
@@ -55,7 +55,7 @@ export const CardStories = () => {
 
       <Card className="h-min">
         <div className="flex flex-col">
-          <p className="text-lg font-bold color-secondary¨">
+          <p className="color-secondary¨ text-lg font-bold">
             Hannah Synnestvedt Gallagher
           </p>
           <a href="mailto:hsg@capraconsulting.no" className="underline">
@@ -102,7 +102,7 @@ export const CardStories = () => {
         }
       >
         <div className="flex flex-col">
-          <p className="text-lg font-bold color-secondary¨">
+          <p className="color-secondary¨ text-lg font-bold">
             Hannah Synnestvedt Gallagher
           </p>
           <a href="mailto:hsg@capraconsulting.no" className="underline">

--- a/app/components/card.tsx
+++ b/app/components/card.tsx
@@ -8,11 +8,11 @@ interface CardProps {
 export const Card = ({ children, image, className }: CardProps) => (
   <div
     className={classNames(
-      "flex flex-col w-full h-full border transition-all shadow hover:shadow-xl",
+      "flex h-full w-full flex-col border shadow transition-all hover:shadow-xl",
       className,
     )}
   >
     {image}
-    <div className="h-full px-3 py-4 flex flex-col gap-5">{children}</div>
+    <div className="flex h-full flex-col gap-5 px-3 py-4">{children}</div>
   </div>
 );

--- a/app/components/content-and-image-box/content-and-image-box.tsx
+++ b/app/components/content-and-image-box/content-and-image-box.tsx
@@ -48,7 +48,7 @@ export const ContentAndImageBox: React.FC<Props> = ({
   return (
     <div
       className={classNames(
-        "flex-col-reverse flex w-full justify-center items-center",
+        "flex w-full flex-col-reverse items-center justify-center",
         {
           "md:flex-row": direction === "left",
           "md:flex-row-reverse": direction === "right",
@@ -57,7 +57,7 @@ export const ContentAndImageBox: React.FC<Props> = ({
     >
       <div
         className={classNames(
-          "w-full md:w-[40vw] lg:w-[60w] md:min-w-[500px] flex flex-col items-start justify-center p-6",
+          "flex w-full flex-col items-start justify-center p-6 md:w-[40vw] md:min-w-[500px] lg:w-[60w]",
           boxClassName,
           {
             "md:pl-[40px] md:pr-[100px]": direction === "left",
@@ -66,16 +66,16 @@ export const ContentAndImageBox: React.FC<Props> = ({
         )}
         style={{ minHeight: height }}
       >
-        <div className="p-[2vw] pb-0 text-2xl md:text-4xl font-bold">
+        <div className="p-[2vw] pb-0 text-2xl font-bold md:text-4xl">
           {title}
         </div>
-        <div className="p-[2vw] whitespace-pre-line text-md md:text-lg">
+        <div className="text-md whitespace-pre-line p-[2vw] md:text-lg">
           {children}
         </div>
         {readMoreLink && (
           <CapraLink
             href={readMoreLink.to}
-            className={`p-[2vw] text-md md:text-lg underline-offset-4 ${
+            className={`text-md p-[2vw] underline-offset-4 md:text-lg ${
               color === "bordeaux" || color === "darkBlue"
                 ? "text-white"
                 : "text-secondary"
@@ -88,7 +88,7 @@ export const ContentAndImageBox: React.FC<Props> = ({
 
       <div
         className={classNames(
-          "relative max-h-60 md:h-[30vw] md:max-h-96 aspect-square shadow-xl bg-white",
+          "relative aspect-square max-h-60 bg-white shadow-xl md:h-[30vw] md:max-h-96",
           {
             "md:-ml-[100px]": direction === "left",
             "md:-mr-[100px]": direction === "right",

--- a/app/components/content-and-slogans-box.tsx
+++ b/app/components/content-and-slogans-box.tsx
@@ -35,7 +35,7 @@ export const ContentAndSlogansBox = ({
   return (
     <div
       className={classNames(
-        "flex-col-reverse flex w-full",
+        "flex w-full flex-col-reverse",
         {
           "md:flex-row": direction === "left",
           "md:flex-row-reverse": direction === "right",
@@ -45,7 +45,7 @@ export const ContentAndSlogansBox = ({
     >
       <div
         className={classNames(
-          "w-full md:w-1/2 pt-[15%] px-[10%] text-secondary",
+          "w-full px-[10%] pt-[15%] text-secondary md:w-1/2",
         )}
       >
         <TitleComponent
@@ -71,14 +71,14 @@ export const ContentAndSlogansBox = ({
           <CapraLink
             href={readMoreHref}
             prefetch="intent"
-            className="text-xl inline-block mt-[10%] md:mt-[25%]"
+            className="mt-[10%] inline-block text-xl md:mt-[25%]"
           >
             Les mer
           </CapraLink>
         )}
       </div>
 
-      <div className="w-full md:w-1/2 grid grid-cols-2 gap-2.5 p-1">
+      <div className="grid w-full grid-cols-2 gap-2.5 p-1 md:w-1/2">
         {slogans.map(({ title, imageUrl }) => (
           <div
             key={title}
@@ -90,7 +90,7 @@ export const ContentAndSlogansBox = ({
             )}
           >
             <CapraImage className="mt-[20%] w-[40%]" src={imageUrl} alt="" />
-            <p className="font-bold absolute bottom-[20%]">{title}</p>
+            <p className="absolute bottom-[20%] font-bold">{title}</p>
           </div>
         ))}
         <CapraImage src={illustrationImageUrl} alt="" />

--- a/app/components/filter-button.tsx
+++ b/app/components/filter-button.tsx
@@ -8,7 +8,7 @@ export const FilterButton = ({ children, active }: FilterButtonProps) => {
   return (
     <span
       className={classNames(
-        "py-1 px-4 rounded border border-secondary transition font-bold text-sm peer-focus:ring-secondary peer-focus:ring-1",
+        "rounded border border-secondary py-1 px-4 text-sm font-bold transition peer-focus:ring-1 peer-focus:ring-secondary",
         {
           "bg-secondary text-white": active,
           "bg-white text-secondary": !active,

--- a/app/components/filter-row.tsx
+++ b/app/components/filter-row.tsx
@@ -29,7 +29,7 @@ export const FilterRow = ({
   };
 
   return (
-    <div className="flex gap-3 flex-wrap">
+    <div className="flex flex-wrap gap-3">
       {filters.map((x) => (
         <label key={x} className="cursor-pointer">
           <input

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -19,7 +19,7 @@ interface FooterModuleProps {
 
 const FooterModule: React.VFC<FooterModuleProps> = ({ title, children }) => (
   <div>
-    <h3 className="uppercase text-white font-bold text-lg mb-0.5">{title}</h3>
+    <h3 className="mb-0.5 text-lg font-bold uppercase text-white">{title}</h3>
     {children}
   </div>
 );
@@ -104,8 +104,8 @@ interface FooterProps {
   >;
 }
 export const Footer = ({ images }: FooterProps) => (
-  <footer className="bg-main border-none flex flex-col gap-10 py-7 items-center">
-    <section className="flex flex-col items-start gap-10 md:gap-0 md:flex-row justify-evenly w-full max-w-6xl px-6 md:px-0">
+  <footer className="flex flex-col items-center gap-10 border-none bg-main py-7">
+    <section className="flex w-full max-w-6xl flex-col items-start justify-evenly gap-10 px-6 md:flex-row md:gap-0 md:px-0">
       <div className="flex flex-col gap-6">
         <FooterModule title="Besøksadresse">
           <FooterLink
@@ -154,7 +154,7 @@ export const Footer = ({ images }: FooterProps) => (
             title="EKT Rideskole og Husdyrpark"
           >
             <CapraImage
-              className="p-1 w-20 rounded bg-white"
+              className="w-20 rounded bg-white p-1"
               src={images["logo-ekt"].imageUrl}
               alt={images["logo-ekt"].alt}
             />
@@ -171,7 +171,7 @@ export const Footer = ({ images }: FooterProps) => (
               title="Capra er Miljøtårnsertifisert"
             >
               <CapraImage
-                className="p-1 w-20 rounded bg-white"
+                className="w-20 rounded bg-white p-1"
                 src={images["logo-miljofyrtaarn"].imageUrl}
                 alt={images["logo-miljofyrtaarn"].alt}
               />
@@ -183,7 +183,7 @@ export const Footer = ({ images }: FooterProps) => (
               title="Capra er ISO-9001-sertifisert - trykk for å se sertifikat"
             >
               <CapraImage
-                className="p-1 w-20 rounded bg-white"
+                className="w-20 rounded bg-white p-1"
                 src={images["logo-quality-sys-cert-iso-9001"].imageUrl}
                 alt={images["logo-quality-sys-cert-iso-9001"].alt}
               />

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -16,24 +16,24 @@ export function Header() {
   return (
     <header
       className={classNames(
-        "flex desktop:justify-between px-6 desktop:px-8 items-center sticky top-0 bottom-0 z-10 transition-none border-solid border-b",
+        "sticky top-0 bottom-0 z-10 flex items-center border-b border-solid px-6 transition-none desktop:justify-between desktop:px-8",
         {
-          "bg-main h-screen flex-col text-white": expanded,
-          "bg-white border-b-[#ccc] max-h-nav-height":
+          "h-screen flex-col bg-main text-white": expanded,
+          "max-h-nav-height border-b-[#ccc] bg-white":
             !expanded && showBottomBorder,
-          "bg-background border-b-transparent max-h-nav-height":
+          "max-h-nav-height border-b-transparent bg-background":
             !expanded && !showBottomBorder,
         },
       )}
     >
-      <div className="flex justify-between w-full desktop:w-auto">
+      <div className="flex w-full justify-between desktop:w-auto">
         <Link to="/" prefetch="render" onClick={() => setExpanded(false)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 842 596"
             aria-label="Capra Consulting - Logo"
             className={classNames(
-              "h-nav-height w-auto inline-block",
+              "inline-block h-nav-height w-auto",
               expanded ? "fill-white" : "fill-black",
             )}
           >
@@ -48,7 +48,7 @@ export function Header() {
       </div>
       <nav
         className={classNames(
-          "flex-col items-center justify-center desktop:flex-row desktop:gap-5 text-3xl desktop:text-lg h-screen desktop:h-auto -mt-nav-height desktop:my-0",
+          "-mt-nav-height h-screen flex-col items-center justify-center text-3xl desktop:my-0 desktop:h-auto desktop:flex-row desktop:gap-5 desktop:text-lg",
           expanded ? "flex" : "hidden desktop:flex",
         )}
       >
@@ -88,7 +88,7 @@ const ToggleMenuButton: React.VFC<ToggleMenuButtonProps> = ({
   );
   return (
     <button
-      className={classNames("desktop:hidden w-8", {
+      className={classNames("w-8 desktop:hidden", {
         relative: isOpen,
       })}
       onClick={() => onToggle(!isOpen)}

--- a/app/components/icon-title-and-text-block.tsx
+++ b/app/components/icon-title-and-text-block.tsx
@@ -13,7 +13,7 @@ const IconTitleAndTextBlock: React.FC<
   return (
     <div className="flex flex-col gap-3 text-center">
       <img src={img} alt={imgAlt} className="max-h-28 sm:max-h-32" />
-      <h3 className="font-bold text-2xl md:text-3xl">{title}</h3>
+      <h3 className="text-2xl font-bold md:text-3xl">{title}</h3>
       <p>{children}</p>
     </div>
   );

--- a/app/components/pattern/pattern-generator.tsx
+++ b/app/components/pattern/pattern-generator.tsx
@@ -100,7 +100,7 @@ export const PatternGenerator: React.FC<Props> = ({
     <svg
       {...size}
       viewBox={`0 0 ${size.width} ${size.height}`}
-      className={classNames(color, "hidden md:block z-9 absolute")}
+      className={classNames(color, "z-9 absolute hidden md:block")}
       style={style}
     >
       {rects}

--- a/app/components/pattern/patterns/l-solid.tsx
+++ b/app/components/pattern/patterns/l-solid.tsx
@@ -26,7 +26,7 @@ export const LSolid: SingleShapePatternComponent = ({ size, color, style }) => {
     <svg
       {...size}
       viewBox={`0 0 ${size.width} ${size.height}`}
-      className={classNames(color, "hidden md:block z-9 absolute")}
+      className={classNames(color, "z-9 absolute hidden md:block")}
       style={style}
     >
       <clipPath id={clipId}>

--- a/app/components/title-and-text.stories.tsx
+++ b/app/components/title-and-text.stories.tsx
@@ -1,7 +1,7 @@
 import { TitleAndText } from "./title-and-text";
 
 export const TitleAndTextStories = () => (
-  <div className="flex flex-col gap-12 items-center">
+  <div className="flex flex-col items-center gap-12">
     <TitleAndText title="Bli en av oss!" titleAs="h2">
       Det skal være skikkelig bra å være ansatt i Capra. Vi vet nemlig at
       kick-ass ansatte er et resultat av en god arbeidsplass - og det ansvaret

--- a/app/components/title-and-text.tsx
+++ b/app/components/title-and-text.tsx
@@ -16,16 +16,16 @@ export const TitleAndText = ({
     <div
       id={id}
       className={classNames(
-        "w-full flex flex-col items-center gap-3 lg:gap-4 text-center",
+        "flex w-full flex-col items-center gap-3 text-center lg:gap-4",
         {
           "scroll-mt-nav-height": !!id,
         },
       )}
     >
-      <TitleComponent className="w-[95%] max-w-7xl font-bold text-3xl md:text-4xl lg:text-6xl text-secondary">
+      <TitleComponent className="w-[95%] max-w-7xl text-3xl font-bold text-secondary md:text-4xl lg:text-6xl">
         {title}
       </TitleComponent>
-      <p className="w-[95%] max-w-4xl font-light text-lg md:text-xl lg:text-2xl text-secondary-80">
+      <p className="w-[95%] max-w-4xl text-lg font-light text-secondary-80 md:text-xl lg:text-2xl">
         {children}
       </p>
     </div>

--- a/app/components/todo.stories.tsx
+++ b/app/components/todo.stories.tsx
@@ -9,7 +9,7 @@ export const TodoStories = () => (
       badge
       size="small"
       display="inline-flex"
-      className="w-48 h-8"
+      className="h-8 w-48"
       title="Liten'ish"
     />
     <div>

--- a/app/components/todo.tsx
+++ b/app/components/todo.tsx
@@ -33,11 +33,11 @@ export const Todo = ({
   return (
     <div
       style={style}
-      className={`${display} relative flex-col justify-center items-center ${rootClassName} ${className}`}
+      className={`${display} relative flex-col items-center justify-center ${rootClassName} ${className}`}
     >
       {badge && (
         <span
-          className={`absolute font-bold bg-yellow border-black text-black rounded ${badgeClassName}`}
+          className={`absolute rounded border-black bg-yellow font-bold text-black ${badgeClassName}`}
         >
           TODO
         </span>

--- a/app/components/typing-text.stories.tsx
+++ b/app/components/typing-text.stories.tsx
@@ -1,7 +1,7 @@
 import { TypingText } from "./typing-text";
 
 export const ViErNorgesBestePaa = () => (
-  <h1 className="font-bold text-3xl md:text-4xl lg:text-6xl">
+  <h1 className="text-3xl font-bold md:text-4xl lg:text-6xl">
     Vi er norges beste på{" "}
     <TypingText
       text={[

--- a/app/components/value-wheel/value-wheel.tsx
+++ b/app/components/value-wheel/value-wheel.tsx
@@ -17,7 +17,7 @@ interface ValueWheelProps {
 export const ValueWheel = (props: ValueWheelProps) => {
   const [active, setActive] = useState(-1);
   return (
-    <div className="w-5/6 max-w-xl my-0 mx-auto">
+    <div className="my-0 mx-auto w-5/6 max-w-xl">
       <Donut
         {...props}
         active={active}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -47,7 +47,7 @@ export default function App() {
         <Meta />
         <Links />
       </head>
-      <body className="flex flex-col h-full">
+      <body className="flex h-full flex-col">
         <Outlet />
         <ScrollRestoration />
         <Scripts />

--- a/app/routes/__layout.tsx
+++ b/app/routes/__layout.tsx
@@ -69,7 +69,7 @@ export default function Layout() {
     <>
       <Header />
       <main className="overflow-x-hidden md:overflow-x-auto">
-        <div className="flex flex-col flex-grow items-center py-12 gap-12 md:gap-36">
+        <div className="flex flex-grow flex-col items-center gap-12 py-12 md:gap-36">
           <Outlet />
         </div>
         {contactFormTitle && (
@@ -102,7 +102,7 @@ export function UnusedCatchBoundary() {
       </head>
       <body>
         <Header />
-        <main className="flex flex-col h-screen">
+        <main className="flex h-screen flex-col">
           {caught.status === 404 && (
             <Todo badge className="h-full" title="404 - Siden ble ikke funnet">
               <Todo title="F.eks. bilde av en søt/forvirret geit" />

--- a/app/routes/__layout/ansatte.tsx
+++ b/app/routes/__layout/ansatte.tsx
@@ -65,7 +65,7 @@ export default function Ansatte() {
   const data = useLoaderData<typeof loader>();
   const [search] = useSearchParams();
   return (
-    <div className="max-w-7xl w-full sm:w-11/12 flex flex-col gap-12">
+    <div className="flex w-full max-w-7xl flex-col gap-12 sm:w-11/12">
       <TitleAndText title="Kontakt oss i Capra" titleAs="h1">
         Vi vil gjerne høre fra deg.
       </TitleAndText>
@@ -79,7 +79,7 @@ export default function Ansatte() {
           />
         </Form>
 
-        <ul className="grid gap-12 sm:gap-10 md:gap-8 lg:gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 justify-center">
+        <ul className="grid grid-cols-1 justify-center gap-12 sm:grid-cols-2 sm:gap-10 md:grid-cols-3 md:gap-8 lg:grid-cols-4 lg:gap-6">
           {data.items.map((x) => (
             <li key={x._id}>
               <AnsattCard employee={x as AuthorExpanded} icons={data.icons} />
@@ -124,7 +124,7 @@ export const AnsattCard = ({
       }
     >
       <div className="flex flex-col items-start">
-        <p className="text-lg font-bold color-secondary¨">{employee.name}</p>
+        <p className="color-secondary¨ text-lg font-bold">{employee.name}</p>
         <a href={`mailto:${employee.email}`} className="underline">
           {employee.email}
         </a>

--- a/app/routes/__layout/bli-en-av-oss.tsx
+++ b/app/routes/__layout/bli-en-av-oss.tsx
@@ -147,14 +147,14 @@ export default function BliEnAvOss() {
   const { images } = useLoaderData<typeof loader>();
   return (
     <>
-      <div className="flex flex-col gap-12 w-full">
+      <div className="flex w-full flex-col gap-12">
         <TitleAndText title="Bli en av oss!" titleAs="h1">
           Det skal være skikkelig bra å være ansatt i Capra. Vi vet nemlig at
           kick-ass ansatte er et resultat av en god arbeidsplass - og det
           ansvaret tar vi på største alvor.
         </TitleAndText>
 
-        <div className="w-11/12 flex gap-4 justify-center">
+        <div className="flex w-11/12 justify-center gap-4">
           <Button
             variant="outline"
             href="https://capraconsulting.teamtailor.com/jobs"
@@ -250,14 +250,14 @@ const JobListingsByDepartment: React.FC = () => {
   const { jobs } = useLoaderData<typeof loader>();
   const groups = groupBy(jobs, (it) => it.department);
   return (
-    <div className="flex flex-col gap-8 w-11/12 max-w-4xl">
+    <div className="flex w-11/12 max-w-4xl flex-col gap-8">
       {Object.entries(groups).map(([department, jobs]) => (
         <details
           key={department}
           className="[&>summary:after]:open:content-['▼']"
           open
         >
-          <summary className="text-2xl font-bold list-none cursor-pointer pb-2 mb-4 border-b border-b-[#ccc] flex justify-between after:self-center after:text-xs after:text-[#ccc] after:content-['►']">
+          <summary className="mb-4 flex cursor-pointer list-none justify-between border-b border-b-[#ccc] pb-2 text-2xl font-bold after:self-center after:text-xs after:text-[#ccc] after:content-['►']">
             {department}
           </summary>
           <ul className="flex flex-col gap-4">

--- a/app/routes/__layout/blogg/$slug.tsx
+++ b/app/routes/__layout/blogg/$slug.tsx
@@ -53,11 +53,11 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => loaderHeaders;
 export default function BloggPost() {
   const item = useLoaderData<typeof loader>();
   return (
-    <article className="w-[90%] max-w-2xl flex flex-col gap-5">
-      <h1 className="text-5xl font-bold text-header leading-[1.14]">
+    <article className="flex w-[90%] max-w-2xl flex-col gap-5">
+      <h1 className="text-5xl font-bold leading-[1.14] text-header">
         {item.titleLong}
       </h1>
-      <ProseableText value={item.ingress!} className="text-brodtext text-2xl" />
+      <ProseableText value={item.ingress!} className="text-2xl text-brodtext" />
 
       <p>
         <span className="text-md block">{item.authors}</span>

--- a/app/routes/__layout/blogg/index.tsx
+++ b/app/routes/__layout/blogg/index.tsx
@@ -64,7 +64,7 @@ export default function BloggIndex() {
   const [search] = useSearchParams();
   return (
     <>
-      <div className="max-w-7xl w-full sm:w-11/12 flex flex-col gap-12">
+      <div className="flex w-full max-w-7xl flex-col gap-12 sm:w-11/12">
         <TitleAndText title="Blogg" titleAs="h1">
           Her på bloggen skriver vi om det som interesserer oss av tech, ting
           som skjer der ute i bransjen vår og andre happenings i Capra.
@@ -79,7 +79,7 @@ export default function BloggIndex() {
             />
           </Form>
 
-          <ul className="grid gap-12 sm:gap-10 md:gap-8 lg:gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 justify-center">
+          <ul className="grid grid-cols-1 justify-center gap-12 sm:grid-cols-2 sm:gap-10 md:grid-cols-3 md:gap-8 lg:grid-cols-4 lg:gap-6">
             {data.items.map((x) => (
               <li key={x._id}>
                 <BloggCard key={x._id} bloggEntry={x as BloggExpanded} />

--- a/app/routes/__layout/dette-har-vi-gjort/$slug.tsx
+++ b/app/routes/__layout/dette-har-vi-gjort/$slug.tsx
@@ -50,11 +50,11 @@ export default function DetteHarViGjortItem() {
   const { item } = useLoaderData<typeof loader>();
 
   return (
-    <article className="w-[90%] max-w-2xl flex flex-col gap-5">
-      <h1 className="text-5xl font-bold text-header leading-[1.14]">
+    <article className="flex w-[90%] max-w-2xl flex-col gap-5">
+      <h1 className="text-5xl font-bold leading-[1.14] text-header">
         {item.titleLong}
       </h1>
-      <ProseableText value={item.ingress!} className="text-brodtext text-2xl" />
+      <ProseableText value={item.ingress!} className="text-2xl text-brodtext" />
 
       <CapraImage
         className="max-w-3xl"

--- a/app/routes/__layout/dette-har-vi-gjort/index.tsx
+++ b/app/routes/__layout/dette-har-vi-gjort/index.tsx
@@ -64,7 +64,7 @@ export default function DetteHarViGjort() {
   const [search] = useSearchParams();
   return (
     <>
-      <div className="max-w-7xl w-full sm:w-11/12 flex flex-col gap-12">
+      <div className="flex w-full max-w-7xl flex-col gap-12 sm:w-11/12">
         <TitleAndText title="Dette har vi gjort for andre" titleAs="h1">
           Vi skaper samfunsnytte for over 1 000 000 brukere hver eneste dag! Her
           har du noen få av tingene våre kick-ass folk gjør for kunder.
@@ -79,7 +79,7 @@ export default function DetteHarViGjort() {
             />
           </Form>
 
-          <ul className="grid gap-12 sm:gap-10 md:gap-8 lg:gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 justify-center">
+          <ul className="grid grid-cols-1 justify-center gap-12 sm:grid-cols-2 sm:gap-10 md:grid-cols-3 md:gap-8 lg:grid-cols-4 lg:gap-6">
             {data.items.map((x) => (
               <li key={x._id}>
                 <SelvskrytCard key={x._id} selvskryt={x as SelvskrytExpanded} />

--- a/app/routes/__layout/dette-kan-vi/index.tsx
+++ b/app/routes/__layout/dette-kan-vi/index.tsx
@@ -60,7 +60,7 @@ export default function DetteKanVi() {
         title="Sky"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images.cloud.imageUrl}
             alt={images.cloud.alt}
           />
@@ -79,7 +79,7 @@ export default function DetteKanVi() {
         direction="right"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images.backend.imageUrl}
             alt={images.backend.alt}
           />
@@ -98,7 +98,7 @@ export default function DetteKanVi() {
         title="Frontend"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images.frontend.imageUrl}
             alt={images.frontend.alt}
           />
@@ -117,7 +117,7 @@ export default function DetteKanVi() {
         direction="right"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images["tech-architecture"].imageUrl}
             alt={images["tech-architecture"].alt}
           />
@@ -134,7 +134,7 @@ export default function DetteKanVi() {
         title="Team-, prosjektleder og smidig coach"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images["project-lead"].imageUrl}
             alt={images["project-lead"].alt}
           />

--- a/app/routes/__layout/index.tsx
+++ b/app/routes/__layout/index.tsx
@@ -73,7 +73,7 @@ export default function Index() {
 
   return (
     <>
-      <div className="flex flex-col gap-12 w-full">
+      <div className="flex w-full flex-col gap-12">
         <TitleAndText
           title={
             <>
@@ -98,7 +98,7 @@ export default function Index() {
         >
           Bold statement? Absolutt.
         </TitleAndText>
-        <div className="w-11/12 mx-auto flex gap-4 justify-center">
+        <div className="mx-auto flex w-11/12 justify-center gap-4">
           <Button variant="outline" href="/dette-kan-vi">
             Bli kunde?
           </Button>
@@ -130,7 +130,7 @@ export default function Index() {
         title="Vi er spesialister"
         image={
           <CapraImage
-            className="w-full h-full object-contain overflow-hidden"
+            className="h-full w-full overflow-hidden object-contain"
             src={images.tech.imageUrl}
             alt={images.tech.alt}
           />
@@ -166,9 +166,9 @@ export default function Index() {
           <strong className="font-bold">offentlig</strong> og{" "}
           <strong className="font-bold">privat</strong> virksomhet
         </TitleAndText>
-        <div className="grid grid-cols-2 w-11/12 max-w-xl mx-auto items-center">
+        <div className="mx-auto grid w-11/12 max-w-xl grid-cols-2 items-center">
           {companies.map(({ alt, imageUrl }) => (
-            <div key={imageUrl} className="flex justify-center items-center">
+            <div key={imageUrl} className="flex items-center justify-center">
               <CapraImage src={imageUrl} alt={alt} />
             </div>
           ))}

--- a/app/routes/__layout/om-oss.tsx
+++ b/app/routes/__layout/om-oss.tsx
@@ -109,7 +109,7 @@ export default function OmOss() {
         bedre.
       </TitleAndText>
 
-      <section className="grid grid-cols-2 sm:grid-cols-3 gap-3 w-[90%] max-w-3xl">
+      <section className="grid w-[90%] max-w-3xl grid-cols-2 gap-3 sm:grid-cols-3">
         {teams.map((props) => (
           <TeamCard key={props.title} {...props} />
         ))}
@@ -120,7 +120,7 @@ export default function OmOss() {
         våre ansatte og våre kunder bedre.
       </TitleAndText>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-20 max-w-4xl px-10">
+      <div className="grid max-w-4xl grid-cols-1 gap-20 px-10 sm:grid-cols-2">
         <IconTitleAndTextBlock
           title="Organisasjon"
           img={images["icon-vision-organization"].imageUrl}
@@ -214,7 +214,7 @@ export default function OmOss() {
         .
       </ContentAndImageBox>
 
-      <section className="flex flex-col gap-12 items-center">
+      <section className="flex flex-col items-center gap-12">
         <TitleAndText title="Tenk selv, fremfor å ha regler" titleAs="h2">
           Kloke mennesker tar kloke valg! Vi vil{" "}
           <strong className="font-bold">
@@ -225,7 +225,7 @@ export default function OmOss() {
 
         <div
           className={classNames(
-            "w-11/12 max-w-xl flex flex-col gap-4",
+            "flex w-11/12 max-w-xl flex-col gap-4",
             // Make the boxes offset on bigger screens
             "md:[&>*:nth-child(even)]:ml-5 md:[&>*:nth-child(odd)]:mr-5",
           )}
@@ -249,12 +249,12 @@ export default function OmOss() {
         linkText="Les om CapraCon"
         href="https://capracon.no"
       />
-      <section className="w-11/12 max-w-6xl flex flex-col gap-12">
+      <section className="flex w-11/12 max-w-6xl flex-col gap-12">
         <TitleAndText title="Kontakt" titleAs="h2">
           Vi vil gjerne høre fra deg!
         </TitleAndText>
 
-        <ul className="flex flex-col sm:flex-row flex-wrap gap-8 sm:gap-10 justify-center">
+        <ul className="flex flex-col flex-wrap justify-center gap-8 sm:flex-row sm:gap-10">
           {contactUsEmployees.map((x) => (
             <li key={x._id} className="w-full sm:w-72 lg:w-80">
               <AnsattCard
@@ -278,11 +278,11 @@ interface InfoBoxProps {
 const InfoBox = ({ title, children, className }: InfoBoxProps) => {
   return (
     <div
-      className={`border-none bg-peach-20 w-11/12 max-w-7xl py-7 px-6 flex flex-col gap-4 ${
+      className={`flex w-11/12 max-w-7xl flex-col gap-4 border-none bg-peach-20 py-7 px-6 ${
         className ?? ""
       }`}
     >
-      <div className="uppercase font-bold text-main">{title}</div>
+      <div className="font-bold uppercase text-main">{title}</div>
       <div>{children}</div>
     </div>
   );
@@ -293,8 +293,8 @@ interface TeamCardProps {
 }
 const TeamCard = ({ title, children }: PropsWithChildren<TeamCardProps>) => {
   return (
-    <div className="bg-white shadow-md py-3 px-4 text-sm">
-      <div className="uppercase font-bold text-main">{title}</div>
+    <div className="bg-white py-3 px-4 text-sm shadow-md">
+      <div className="font-bold uppercase text-main">{title}</div>
       <div>{children}</div>
     </div>
   );

--- a/app/routes/__layout/partnere.tsx
+++ b/app/routes/__layout/partnere.tsx
@@ -20,8 +20,8 @@ export default function Partnere() {
         kompetansemiljøene på AWS.
       </TitleAndText>
 
-      <Todo badge className="py-0 px-0 w-full" title="">
-        <div className="bg-peach-20 flex flex-row items-center py-[5%] px-[10%] ">
+      <Todo badge className="w-full py-0 px-0" title="">
+        <div className="flex flex-row items-center bg-peach-20 py-[5%] px-[10%] ">
           <div>
             Som{" "}
             <a
@@ -38,7 +38,7 @@ export default function Partnere() {
           </div>
           <Todo
             title="AWS partner network bilde"
-            className="w-[340px] h-[90px] py-0 px-0"
+            className="h-[90px] w-[340px] py-0 px-0"
           />
         </div>
       </Todo>
@@ -50,7 +50,7 @@ export default function Partnere() {
 
       <Todo
         badge
-        className="py-0 px-y h-[500px]"
+        className="px-y h-[500px] py-0"
         title="Kode 24 | Oslo Architect | Teknologihuset | Kongsvinger Tennisklubb"
       ></Todo>
 

--- a/app/routes/api.contact.tsx
+++ b/app/routes/api.contact.tsx
@@ -118,9 +118,9 @@ export const ContactForm = ({ title, representatives }: ContactFormProps) => {
   const isSuccess = fetcher.type === "done" && !fetcher.data;
   return (
     <div className="bg-secondary pt-[3vh] pb-[6vh]">
-      <article className="flex flex-col items-center text-white w-10/12 sm:w-9/12 md:11/12 mx-auto">
+      <article className="md:11/12 mx-auto flex w-10/12 flex-col items-center text-white sm:w-9/12">
         <section className="text-center">
-          <p className="text-xl md:text-4xl font-bold text-peach">
+          <p className="text-xl font-bold text-peach md:text-4xl">
             {isSuccess ? "Takk for din interesse!" : title}
           </p>
           <p className="md:mt-5">
@@ -129,11 +129,11 @@ export const ContactForm = ({ title, representatives }: ContactFormProps) => {
               : "Fyll ut skjemaet så kontakter vi deg!"}
           </p>
         </section>
-        <section className="grid grid-cols-1 lg:grid-cols-2 w-full max-w-7xl gap-12">
+        <section className="grid w-full max-w-7xl grid-cols-1 gap-12 lg:grid-cols-2">
           <fetcher.Form
             method="post"
             action="/api/contact"
-            className="w-full flex flex-col gap-[4vh]"
+            className="flex w-full flex-col gap-[4vh]"
             name="contact"
           >
             <Input
@@ -209,7 +209,7 @@ interface RepresentativesProps {
 }
 const Representatives = ({ representatives }: RepresentativesProps) => {
   return (
-    <div className="grid grid-flow-dense grid-cols-1 md:grid-cols-2 gap-y-5 gap-x-14 px-5">
+    <div className="grid grid-flow-dense grid-cols-1 gap-y-5 gap-x-14 px-5 md:grid-cols-2">
       {representatives.map(({ name, email, image }) => (
         <div key={name} className="flex flex-col">
           <CapraImage

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-simple-import-sort": "8.0.0",
         "npm-run-all": "4.1.5",
         "prettier": "2.7.1",
+        "prettier-plugin-tailwindcss": "0.1.13",
         "tailwindcss": "3.2.2",
         "typescript": "4.8.4",
         "wrangler": "2.1.15"
@@ -13442,6 +13443,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=2.2.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -26733,6 +26746,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.13.tgz",
+      "integrity": "sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-format": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-simple-import-sort": "8.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.7.1",
+    "prettier-plugin-tailwindcss": "0.1.13",
     "tailwindcss": "3.2.2",
     "typescript": "4.8.4",
     "wrangler": "2.1.15"


### PR DESCRIPTION
this offical tailwind prettier plugin gives an opinionated sort order of classes. when get used this order I belive it will make reading the styling easier. also since prettier autoformats we don't have to care about positioning when writing the styling code, just write, click save, and it's positioned correctly.

https://tailwindcss.com/blog/automatic-class-sorting-with-prettier
https://github.com/tailwindlabs/prettier-plugin-tailwindcss