### PR TITLE
:recycle: make h3 come in as a explicit prop

### DIFF
--- a/app/components/icon-title-and-text-block.tsx
+++ b/app/components/icon-title-and-text-block.tsx
@@ -3,17 +3,20 @@ import React from "react";
 
 type IconTitleAndTextBlockProps = {
   title: string;
+  titleAs: "h1" | "h2" | "h3" | "h4";
   img: string;
   imgAlt: string;
 };
 
 const IconTitleAndTextBlock: React.FC<
   PropsWithChildren<IconTitleAndTextBlockProps>
-> = ({ title, children, img, imgAlt }) => {
+> = ({ title, titleAs: TitleComponent, children, img, imgAlt }) => {
   return (
     <div className="flex flex-col gap-3 text-center">
       <img src={img} alt={imgAlt} className="max-h-28 sm:max-h-32" />
-      <h3 className="text-2xl font-bold md:text-3xl">{title}</h3>
+      <TitleComponent className="text-2xl font-bold md:text-3xl">
+        {title}
+      </TitleComponent>
       <p>{children}</p>
     </div>
   );

--- a/app/routes/__layout/om-oss.tsx
+++ b/app/routes/__layout/om-oss.tsx
@@ -123,6 +123,7 @@ export default function OmOss() {
       <div className="grid max-w-4xl grid-cols-1 gap-20 px-10 sm:grid-cols-2">
         <IconTitleAndTextBlock
           title="Organisasjon"
+          titleAs="h3"
           img={images["icon-vision-organization"].imageUrl}
           imgAlt={images["icon-vision-organization"].alt}
         >
@@ -131,6 +132,7 @@ export default function OmOss() {
         </IconTitleAndTextBlock>
         <IconTitleAndTextBlock
           title="Forretningsutvikling"
+          titleAs="h3"
           img={images["icon-vision-development"].imageUrl}
           imgAlt={images["icon-vision-development"].imageUrl}
         >
@@ -139,6 +141,7 @@ export default function OmOss() {
         </IconTitleAndTextBlock>
         <IconTitleAndTextBlock
           title="Markedsføring"
+          titleAs="h3"
           img={images["icon-vision-marketing"].imageUrl}
           imgAlt={images["icon-vision-marketing"].alt}
         >
@@ -148,6 +151,7 @@ export default function OmOss() {
         </IconTitleAndTextBlock>
         <IconTitleAndTextBlock
           title="Kompetanse"
+          titleAs="h3"
           img={images["icon-vision-competence"].imageUrl}
           imgAlt={images["icon-vision-competence"].alt}
         >


### PR DESCRIPTION
same as `title-and-text` component

headings should be in correct order, and this component might be used directly under a h1, or even under a h3, we don't know

I think it's better to leave it to the user of the component

also makes it clearer when looking at the page code

https://www.w3.org/WAI/tutorials/page-structure/headings/