### PR TITLE
:lipstick: inline backtick code styling with background instead of visible ` characters

### DIFF
--- a/app/components/ProsableText.tsx
+++ b/app/components/ProsableText.tsx
@@ -66,6 +66,9 @@ export const ProseableText = ({ value, className }: ProseableTextProps) => {
         className,
         "prose-blockquote:border-l-blue",
         "prose-h2:mb-0 prose-h2:text-header",
+
+        "prose-code:before:content-none prose-code:after:content-none",
+        "prose-code:bg-secondary-7 prose-code:py-0.5 prose-code:px-1 prose-code:font-monospace prose-code:font-light",
       )}
     >
       <PortableText

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     fontFamily: {
       sans: ["'Source Sans Pro'", "sans-serif"],
       serif: ["'Source Sans Pro'", "serif"],
+      monospace: ["monospace"],
     },
     extend: {
       spacing: {


### PR DESCRIPTION
Denne PR'en
https://backtick-code-with-backgroun.nettsiden.pages.dev/blogg/nyheter-i-javascript-es2022
<img width="676" alt="image" src="https://user-images.githubusercontent.com/244257/201425265-6d7743db-558c-4ba2-a302-77ae5b4734b8.png">

Nåværende i `main`
https://nettsiden.pages.dev/blogg/nyheter-i-javascript-es2022
<img width="690" alt="image" src="https://user-images.githubusercontent.com/244257/201425317-8ecabdc5-642c-49b4-94e0-d9e3267176df.png">

Opprinnelige fra gatsby repo'et i PROD
https://www.capraconsulting.no/blogg/nyheter-i-javascript-es2022/
<img width="786" alt="image" src="https://user-images.githubusercontent.com/244257/201425346-5aa7117c-da90-4813-8bba-df9bbcea40d1.png">

