### PR TITLE
:zap: self-host source-sans-pro font

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,6 +8,8 @@ import {
 } from "@remix-run/react";
 import type { LinksFunction } from "@remix-run/server-runtime";
 
+import sourceSansStyles from "@fontsource/source-sans-pro/latin.css";
+
 import globalStyles from "./global.css";
 import tailwindStyles from "./tailwind.css";
 
@@ -31,7 +33,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: tailwindStyles },
   {
     rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900&display=swap",
+    href: sourceSansStyles,
+    // href: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700,900&display=swap",
   },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "capraconsulting-nettsiden",
       "dependencies": {
+        "@fontsource/source-sans-pro": "4.5.11",
         "@portabletext/react": "2.0.0",
         "@remix-run/cloudflare": "1.11.1",
         "@remix-run/react": "1.11.1",
@@ -2463,6 +2464,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@fontsource/source-sans-pro": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-4.5.11.tgz",
+      "integrity": "sha512-f7iw44q1EjBv3MNcHCGAgrW/QVyweaEouFsJzykPhTOGnZFSwFJRISToXornOmuAy7xUUGiVdqOLiykgZoYB8A=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -19458,6 +19464,11 @@
           "dev": true
         }
       }
+    },
+    "@fontsource/source-sans-pro": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-4.5.11.tgz",
+      "integrity": "sha512-f7iw44q1EjBv3MNcHCGAgrW/QVyweaEouFsJzykPhTOGnZFSwFJRISToXornOmuAy7xUUGiVdqOLiykgZoYB8A=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "@fontsource/source-sans-pro": "4.5.11",
     "@portabletext/react": "2.0.0",
     "@remix-run/cloudflare": "1.11.1",
     "@remix-run/react": "1.11.1",


### PR DESCRIPTION
[Deployed her](https://bundle-source-sans-pro-inste.nettsiden.pages.dev/)

## Burde vi self-hoste?
Jeg tror ja. Vi bruker cloudflare, on the edge, som støtter http/2 (og [http/3](https://www.cloudflare.com/en-gb/learning/performance/what-is-http3/))

Hadde vi fortsatt vært på en enkel netlify server i tyskland hadde svaret kanskje vært nei.

https://web.dev/font-best-practices/#using-self-hosted-fonts
https://almanac.httparchive.org/en/2020/fonts#self-hosting-isnt-always-better
https://www.tunetheweb.com/blog/should-you-self-host-google-fonts/

## Lighthouse resultat

Med lighthouse i chrome fra maskinen min var det nesten ingen forskjell
Første gang jeg testet med `pagespeed.web.dev` var det en betydelig forskjell i score. Gjentatte forsøk gir litt diverse resultater, noen faktisk litt dårligere 🤔 🤷 

<img width="977" alt="image" src="https://user-images.githubusercontent.com/244257/214165518-c07b55f6-d7a3-4c1a-b7af-a5eebe02622c.png">


| Med google fonts  | Self-hosted |
| ------------- | ------------- |
| [Rapport](https://pagespeed.web.dev/report?url=https%3A%2F%2Fnettsiden.pages.dev%2F)  | [Rapport](https://pagespeed.web.dev/report?url=https%3A%2F%2Fbundle-source-sans-pro-inste.nettsiden.pages.dev%2F)  |
| <img width="980" alt="image" src="https://user-images.githubusercontent.com/244257/214165376-1baad79a-349d-4267-b148-c25106047d04.png">  | <img width="960" alt="image" src="https://user-images.githubusercontent.com/244257/214165400-e9ca967f-e085-47d6-bfa0-80a941bf9ca7.png">
  |


