### PR TITLE
:art: New icons for TPU-page

### DIFF
--- a/app/routes/__layout/dette-kan-vi/workshops.tsx
+++ b/app/routes/__layout/dette-kan-vi/workshops.tsx
@@ -28,9 +28,9 @@ function cropper(builder: ImageUrlBuilder): ImageUrlBuilder {
 export async function loader() {
   const [images, contacts] = await Promise.all([
     fetchImageAssets([
-      "icon-competence-red",
-      "icon-technical-red",
-      "icon-time-red",
+      "icon-connected-people-red",
+      "icon-medal-red",
+      "icon-learning-light-bulb-red",
       ["photo-people-and-dog", cropper],
       ["photo-whiteboard-hga-sba", cropper],
     ]),
@@ -83,7 +83,7 @@ export default function Workshops() {
           <IconTitleAndTextBlock
             title="Beste praksis"
             titleAs="h2"
-            image={images["icon-technical-red"]}
+            image={images["icon-medal-red"]}
           >
             Vi oppdaterer oss kontinuerlig på beste praksis i markedet, og gir
             forslag basert på din kultur og domene.
@@ -91,7 +91,7 @@ export default function Workshops() {
           <IconTitleAndTextBlock
             title="Læring først"
             titleAs="h2"
-            image={images["icon-time-red"]}
+            image={images["icon-learning-light-bulb-red"]}
           >
             I Capra er vi veldig opptatte av kontinuerlig læring. Derfor tester
             vi alltid nye rammeverk og måter å jobbe på internt først.
@@ -100,7 +100,7 @@ export default function Workshops() {
           <IconTitleAndTextBlock
             title="Tett koblet fagmiljø"
             titleAs="h2"
-            image={images["icon-competence-red"]}
+            image={images["icon-connected-people-red"]}
           >
             Et lite, men sterkt fokusert fagmiljø, preget av åpenhet og deling,
             gir deg kortere vei til relevante erfaringer.


### PR DESCRIPTION
Endret ikonene på TPU-siden. Har tegnet abonnoment på [The Noun Project](https://thenounproject.com/).


Forslag:

<img width="958" alt="image" src="https://user-images.githubusercontent.com/6966584/222148662-8197797d-2c43-449c-877e-6f669a043b6b.png">

Slik ser det ut i prod:

<img width="934" alt="image" src="https://user-images.githubusercontent.com/6966584/222148763-e5f15f3e-7339-430c-aa06-f4095d773a5d.png">
