### PR TITLE
⬆️ Node 18 in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "wrangler": "3.1.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
As Node 16 is EOL September 2023, it would be a good idea to specify this in package.json